### PR TITLE
remove dkube-db-pvc spec

### DIFF
--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -207,22 +207,6 @@ metadata:
   namespace: dkube
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    ksonnet.io/component: service
-  name: dkube-db-pvc
-  namespace: dkube
-spec:
-  accessModes:
-  - ReadWriteMany
-  resources:
-    requests:
-      storage: 50Gi
-  storageClassName: ""
-  volumeName: dkube-db-pv
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:


### PR DESCRIPTION
dkube-db-pvc spec is added in installer pod hence removing the duplicate here (https://github.com/oneconvergence/gpuaas/pull/6484)