### PR TITLE
Configure ETCD password

### DIFF
--- a/kustomize-nfs/dkube/base/dkube.yaml
+++ b/kustomize-nfs/dkube/base/dkube.yaml
@@ -401,6 +401,8 @@ spec:
       nodeSelector: NODE_SELECTOR
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccount: dkube
+      serviceAccountName: dkube
       terminationGracePeriodSeconds: 30
 ---
 apiVersion: apps/v1

--- a/kustomize/dkube/base/dkube.yaml
+++ b/kustomize/dkube/base/dkube.yaml
@@ -410,6 +410,8 @@ spec:
       nodeSelector: NODE_SELECTOR
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccount: dkube
+      serviceAccountName: dkube
       terminationGracePeriodSeconds: 30
 ---
 apiVersion: apps/v1

--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -537,6 +537,7 @@ spec:
             - exact: d3-uname
             - exact: d3-role
             - exact: x-cluster-id
+            - exact: Authorization
         serverUri:
           cluster: outbound|3001||dkube-auth-server.dkube.svc.cluster.local
           failureModeAllow: false


### PR DESCRIPTION
fix for https://github.com/oneconvergence/gpuaas/issues/6023

1. Use dkube service account for dfab-proxy as it needs access to the dkube-etcd-secret in dkube-infra ns
2. Add pass Authorization header to upstream service. 
This is for the etcd external endpoint https://<ip>:32222/dkube/v2/etcd. This end point is used by the dkubectl db dump command. dkubectl sends the token in the Authorization header. This is validated in d3auth and d3auth will set the Basic auth header required for etcd.