### PR TITLE
Prometheus image version change and enabled admin api

### DIFF
--- a/kustomize/monitoring/base/monitoring.yaml
+++ b/kustomize/monitoring/base/monitoring.yaml
@@ -553,11 +553,12 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.13.1
+          image: prom/prometheus:v2.15.1
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
             - "--storage.tsdb.retention.time=3650d"
+            - "--web.enable-admin-api"
           ports:
             - containerPort: 9090
           volumeMounts:


### PR DESCRIPTION
Changed prometheus docker image version from 2.13.1 to 2.15.1
Added an argument "web.enable-admin-api" for taking a snapshot of prometheus data during backup

This pr is in reference to the other pr where the backup and restore code is written https://github.com/oneconvergence/gpuaas/pull/7099
Both have to be merged together.