### PR TITLE
API request timeout

### DIFF
--- a/kustomize/minio/base/minio.yaml
+++ b/kustomize/minio/base/minio.yaml
@@ -44,10 +44,10 @@ spec:
   - match:
     - uri:
         prefix: /minio/
+      method:
+        exact: GET
     rewrite:
         uri: /
-    method:
-      exact: GET
     route:
     - destination:
         port:

--- a/kustomize/minio/base/minio.yaml
+++ b/kustomize/minio/base/minio.yaml
@@ -46,8 +46,8 @@ spec:
         prefix: /minio/
     rewrite:
         uri: /
-      method:
-        exact: GET
+    method:
+      exact: GET
     route:
     - destination:
         port:

--- a/kustomize/minio/base/minio.yaml
+++ b/kustomize/minio/base/minio.yaml
@@ -46,6 +46,8 @@ spec:
         prefix: /minio/
     rewrite:
         uri: /
+      method:
+        exact: GET
     route:
     - destination:
         port:
@@ -53,8 +55,20 @@ spec:
         host: dkube-minio-server
     retries:
       attempts: 3
-      perTryTimeout: 5s
+      perTryTimeout: 60s
       retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
+  - match:
+    - uri:
+        prefix: /minio/
+    rewrite:
+        uri: /
+    route:
+    - destination:
+        port:
+          number: 9000
+        host: dkube-minio-server
+    timeout: 60s
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -625,12 +625,17 @@ spec:
     - uri:
         prefix: /dex
       method:
-        exact: POST
+        exact: GET
     route:
     - destination:
         port:
           number: 5556
         host: dkube-auth-server
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /dex
@@ -639,25 +644,12 @@ spec:
         port:
           number: 5556
         host: dkube-auth-server
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
   - match:
     - uri:
         prefix: /dkube/v2/login
       method:
-        exact: POST
-    rewrite:
-        uri: /login
-    route:
-    - destination:
-        port:
-          number: 3001
-        host: dkube-auth-server
-  - match:
-    - uri:
-        prefix: /dkube/v2/login
+        exact: GET
     rewrite:
         uri: /login
     route:
@@ -667,23 +659,25 @@ spec:
         host: dkube-auth-server
     retries:
       attempts: 3
-      perTryTimeout: 5s
+      perTryTimeout: 60s
       retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
-        prefix: /dkube/v2/logout
-      method:
-        exact: POST
+        prefix: /dkube/v2/login
     rewrite:
-        uri: /logout
+        uri: /login
     route:
     - destination:
         port:
           number: 3001
         host: dkube-auth-server
+    timeout: 60s
   - match:
     - uri:
         prefix: /dkube/v2/logout
+      method:
+        exact: GET
     rewrite:
         uri: /logout
     route:
@@ -693,8 +687,20 @@ spec:
         host: dkube-auth-server
     retries:
       attempts: 3
-      perTryTimeout: 5s
+      perTryTimeout: 60s
       retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
+  - match:
+    - uri:
+        prefix: /dkube/v2/logout
+    rewrite:
+        uri: /logout
+    route:
+    - destination:
+        port:
+          number: 3001
+        host: dkube-auth-server
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -711,7 +717,7 @@ spec:
     - uri:
         prefix: /docs
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /docs
     route:
@@ -719,6 +725,11 @@ spec:
         port:
           number: 8888
         host: dkube-docs
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /docs
@@ -729,15 +740,12 @@ spec:
         port:
           number: 8888
         host: dkube-docs
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
   - match:
     - uri:
         prefix: /pagespeed
       method:
-        exact: POST
+        exact: GET
     rewrite:
       uri: /pagespeed
     route:
@@ -745,13 +753,14 @@ spec:
         host: dkube-docs
         port:
           number: 8888
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /pagespeed
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
     rewrite:
       uri: /pagespeed
     route:
@@ -759,11 +768,12 @@ spec:
         host: dkube-docs
         port:
           number: 8888
+    timeout: 60s
   - match:
     - uri:
         prefix: /mod_pagespeed_beacon
       method:
-        exact: POST
+        exact: GET
     rewrite:
       uri: /mod_pagespeed_beacon
     route:
@@ -771,13 +781,14 @@ spec:
         host: dkube-docs
         port:
           number: 8888
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /mod_pagespeed_beacon
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
     rewrite:
       uri: /mod_pagespeed_beacon
     route:
@@ -785,6 +796,7 @@ spec:
         host: dkube-docs
         port:
           number: 8888
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -801,7 +813,7 @@ spec:
     - uri:
         prefix: /dkube/v2/ext
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /dkube/v2
     route:
@@ -809,6 +821,11 @@ spec:
         port:
           number: 9401
         host: dkube-downloader
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /dkube/v2/ext
@@ -819,15 +836,12 @@ spec:
         port:
           number: 9401
         host: dkube-downloader
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
   - match:
     - uri:
         prefix: /dkube/pipeline/logs/
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /dkube/v2/kubeflow/
     route:
@@ -835,6 +849,11 @@ spec:
         port:
           number: 9401
         host: dkube-downloader
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /dkube/pipeline/logs/
@@ -845,10 +864,7 @@ spec:
         port:
           number: 9401
         host: dkube-downloader
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -864,6 +880,8 @@ spec:
   - match:
     - uri:
         prefix: /dkube/v2/operator
+      method:
+        exact: GET
     route:
     - destination:
         port:
@@ -871,8 +889,18 @@ spec:
         host: dkube-operator-api-proxy
     retries:
       attempts: 3
-      perTryTimeout: 5s
+      perTryTimeout: 60s
       retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
+  - match:
+    - uri:
+        prefix: /dkube/v2/operator
+    route:
+    - destination:
+        port:
+          number: 8000
+        host: dkube-operator-api-proxy
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -889,7 +917,7 @@ spec:
     - uri:
         prefix: /dkube/grafana/
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /
     route:
@@ -897,6 +925,11 @@ spec:
         port:
           number: 80
         host: dkube-grafana
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /dkube/grafana/
@@ -907,10 +940,7 @@ spec:
         port:
           number: 80
         host: dkube-grafana
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -927,7 +957,7 @@ spec:
     - uri:
         prefix: /dkube/v2/prometheus/api/v1
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /api/v1
     route:
@@ -935,6 +965,11 @@ spec:
         port:
           number: 9090
         host: dkube-prometheus.dkube.svc.cluster.local
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /dkube/v2/prometheus/api/v1
@@ -945,10 +980,7 @@ spec:
         port:
           number: 9090
         host: dkube-prometheus.dkube.svc.cluster.local
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -965,12 +997,17 @@ spec:
     - uri:
         prefix: /inference
       method:
-        exact: POST
+        exact: GET
     route:
     - destination:
         port:
           number: 8000
         host: dkube-serving
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /inference
@@ -979,20 +1016,22 @@ spec:
         port:
           number: 8000
         host: dkube-serving
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
   - match:
     - uri:
         prefix: /predict
       method:
-        exact: POST
+        exact: GET
     route:
     - destination:
         port:
           number: 8000
         host: dkube-serving
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /predict
@@ -1001,10 +1040,7 @@ spec:
         port:
           number: 8000
         host: dkube-serving
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1033,6 +1069,7 @@ spec:
       attempts: 10
       perTryTimeout: 1s
       retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1049,7 +1086,7 @@ spec:
     - uri:
         prefix: /argo/logs/
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /api/logs/
     route:
@@ -1061,6 +1098,11 @@ spec:
         response:
           add:
             Cache-Control: no-cache, max-age=0
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /argo/logs/
@@ -1075,10 +1117,7 @@ spec:
         response:
           add:
             Cache-Control: no-cache, max-age=0
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1095,7 +1134,7 @@ spec:
     - uri:
         prefix: /katib
       method:
-        exact: POST
+        exact: GET
     route:
     - destination:
         port:
@@ -1105,6 +1144,11 @@ spec:
         response:
           add:
             Cache-Control: no-cache, max-age=0
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /katib
@@ -1117,10 +1161,7 @@ spec:
         response:
           add:
             Cache-Control: no-cache, max-age=0
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1166,6 +1207,7 @@ spec:
         port:
           number: 9090
         host: metadata-envoy-service.kubeflow.svc.cluster.local
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1186,6 +1228,7 @@ spec:
         host: profiles-kfam.kubeflow.svc.cluster.local
         port:
           number: 8081
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1202,7 +1245,7 @@ spec:
     - uri:
         prefix: /installer
       method:
-        exact: POST
+        exact: GET
     rewrite:
         uri: /ui
     route:
@@ -1210,6 +1253,11 @@ spec:
         port:
           number: 8888
         host: dkube-installer-service
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /installer
@@ -1220,20 +1268,22 @@ spec:
         port:
           number: 8888
         host: dkube-installer-service
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
   - match:
     - uri:
         prefix: /report
       method:
-        exact: POST
+        exact: GET
     route:
     - destination:
         port:
           number: 8888
         host: dkube-installer-service
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /report
@@ -1242,10 +1292,7 @@ spec:
         port:
           number: 8888
         host: dkube-installer-service
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -1270,18 +1317,9 @@ spec:
         host: dkube-controller-worker
     retries:
       attempts: 3
-      perTryTimeout: 5s
+      perTryTimeout: 60s
       retryOn: gateway-error,connect-failure,refused-stream
-  - match:
-    - uri:
-        prefix: /dkube/v2/controller
-      method:
-        exact: POST
-    route:
-    - destination:
-        port:
-          number: 5000
-        host: dkube-controller-master
+    timeout: 4m
   - match:
     - uri:
         prefix: /dkube/v2/controller
@@ -1290,20 +1328,22 @@ spec:
         port:
           number: 5000
         host: dkube-controller-master
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
   - match:
     - uri:
         prefix: /api/2.0/mlflow
       method:
-        exact: POST
+        exact: GET
     route:
     - destination:
         port:
           number: 5002
         host: dkube-controller-master
+    retries:
+      attempts: 3
+      perTryTimeout: 60s
+      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 4m
   - match:
     - uri:
         prefix: /api/2.0/mlflow
@@ -1312,10 +1352,7 @@ spec:
         port:
           number: 5002
         host: dkube-controller-master
-    retries:
-      attempts: 3
-      perTryTimeout: 5s
-      retryOn: gateway-error,connect-failure,refused-stream
+    timeout: 60s
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
1. Removed retry from all methods except GET
2. Added API request timeout of 4m for GET methods and 60sec for all other methods

This PR fixes 
https://github.com/oneconvergence/gpuaas/issues/7373
