### PR TITLE
Update envoy filter timeout to 30s

### DIFF
--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -523,7 +523,7 @@ spec:
                 - exact: x-cluster-id
             serverUri:
               cluster: outbound|3001||dkube-auth-server.dkube.svc.cluster.local
-              timeout: 10s
+              timeout: 30s
               uri: http://dkube-auth-server.dkube.svc.cluster.local
           failure_mode_allow: false
           status_on_error: 


### PR DESCRIPTION
Fix for https://github.com/oneconvergence/gpuaas/issues/8678

Update envoy filter timeout to 30s