### PR TITLE
Modelmonitor minio fixes

### DIFF
--- a/kustomize/minio/base/minio.yaml
+++ b/kustomize/minio/base/minio.yaml
@@ -116,7 +116,7 @@ spec:
           value: dkube
         - name: MINIO_SECRET_KEY
           value: minioSecretKey
-        image: minio/minio:RELEASE.2020-07-02T00-15-09Z
+        image: minio/minio:RELEASE.2022-02-26T02-54-46Z
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/kustomize/minio/base/minio.yaml
+++ b/kustomize/minio/base/minio.yaml
@@ -18,11 +18,26 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: dkube-minio-server
+  name: dkube-minio-console-server
   namespace: dkube-infra
 spec:
   ports:
   - nodePort: 32223
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: minio
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dkube-minio-server
+  namespace: dkube-infra
+spec:
+  ports:
+  - nodePort: 32221
     port: 9000
     protocol: TCP
     targetPort: 9000
@@ -91,6 +106,10 @@ spec:
       containers:
       - args:
         - server
+        - --address
+        - :9000
+        - --console-address
+        - :9001
         - /storage
         env:
         - name: MINIO_ACCESS_KEY
@@ -102,6 +121,8 @@ spec:
         name: main
         ports:
         - containerPort: 9000
+          protocol: TCP
+        - containerPort: 9001
           protocol: TCP
         resources:
           limits:


### PR DESCRIPTION
- Upgraded minio version
- New minio has 2 ports:
-- API Port: 9000 (For API or mc requests)
-- Console Port: {Manually set to 9001 by us else dynamically assigned} (For UI requests)
- Hence:
-- Exposed 9000 port using new 32221 Nodeport svc for API reqs.
-- Exposed 9001 port using existing 32223 Nodeport svc for UI reqs.