### PR TITLE
Increase logging flush interval

### DIFF
--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -198,7 +198,7 @@ data:
          retry_type periodic
          retry_wait 10s
          flush_mode interval
-         flush_interval 60s
+         flush_interval 30s
          flush_at_shutdown true
        </buffer>
     </match>

--- a/kustomize/service/base/service.yaml
+++ b/kustomize/service/base/service.yaml
@@ -197,7 +197,8 @@ data:
          overflow_action throw_exception
          retry_type periodic
          retry_wait 10s
-         flush_mode immediate
+         flush_mode interval
+         flush_interval 60s
          flush_at_shutdown true
        </buffer>
     </match>


### PR DESCRIPTION
- Increased logging flush interval from immediate to 30s.
- Fix for https://github.com/oneconvergence/gpuaas/issues/9040