### PR TITLE
Removed unnecessary empty storage volume for grafana

### DIFF
--- a/kustomize/monitoring/base/monitoring.yaml
+++ b/kustomize/monitoring/base/monitoring.yaml
@@ -1707,8 +1707,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /var/lib/grafana
-          name: grafana-storage
         - mountPath: /etc/grafana/grafana.ini
           name: grafana-config
           subPath: grafana.ini
@@ -1747,7 +1745,6 @@ spec:
       serviceAccountName: dkube-prometheus
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: grafana-storage
       - configMap:
           defaultMode: 420
           name: dkube-grafana-dashboard


### PR DESCRIPTION
- Grafana stores its plugins at /var/lib/grafana/plugins
- ocdr/dkube-grafana:8.4.4 has a plugin built inside the image at above location.
- This empty dir volume overwrites the existing plugin in the image with an empty dir.
- Hence removing the empty dir volume.
- Fix for https://github.com/oneconvergence/gpuaas/issues/9357